### PR TITLE
Fixed use of uninitialized local variable "loc" which caused unwanted…

### DIFF
--- a/IP2Location.pas
+++ b/IP2Location.pas
@@ -646,14 +646,19 @@ end;
 // Description: Open the IP2Location database file
 function IP2Location_open(db:PChar):TIP2Location;
 var f:integer;
-var loc:TIP2Location;
+    loc:TIP2Location;
 begin
+FillChar(loc, SizeOf(TIP2Location), #0);
+
+Result := loc;
+
 f:=FileOpen(db,fmOpenRead);
 if f <> INVALID_HANDLE_VALUE then
 	begin
-	result.filehandle:=f;
-	IP2Location_initialize(result);
+	loc.filehandle:=f;
+	IP2Location_initialize(loc);
 	if loc.productcode = 1 then
+    Result := loc
 	else
 		if ((loc.databaseyear <= 20) and (loc.productcode = 0)) then
 			begin


### PR DESCRIPTION
… call to IP2Location_DB_close function.

In condition `if loc.productcode = 1 then` local variable "loc" is not initialized yet. Also it's better to clear "Result" in the very beginning to avoid side effects.